### PR TITLE
Chat completion: messages, stop, temperature, top_p, model, max_completion_tokens

### DIFF
--- a/examples/openai-client.py
+++ b/examples/openai-client.py
@@ -29,6 +29,7 @@ stream = client.chat.completions.create(
     model=model, 
 	messages=messages, 
 	max_completion_tokens=200,
+	stop=["4.", "sushi"],
 	stream=True
 )
 

--- a/examples/openai-client.py
+++ b/examples/openai-client.py
@@ -31,6 +31,7 @@ stream = client.chat.completions.create(
 	max_completion_tokens=200,
 	stop=["4.", "sushi"],
 	top_p=0.3,
+	# temperature=2.0,
 	stream=True
 )
 

--- a/examples/openai-client.py
+++ b/examples/openai-client.py
@@ -1,7 +1,7 @@
 from openai import OpenAI
 
-model = "llama"
-# model = "smolm2-135m"
+# model = "llama"
+model = "smolm2-135m"
 # model = "olmo-7b"
 uri = "http://localhost:8000/v1/"
 
@@ -28,7 +28,7 @@ messages = [
 stream = client.chat.completions.create(
     model=model, 
 	messages=messages, 
-	max_tokens=500,
+	max_completion_tokens=200,
 	stream=True
 )
 

--- a/examples/openai-client.py
+++ b/examples/openai-client.py
@@ -30,6 +30,7 @@ stream = client.chat.completions.create(
 	messages=messages, 
 	max_completion_tokens=200,
 	stop=["4.", "sushi"],
+	top_p=0.3,
 	stream=True
 )
 

--- a/llama_cpp/server/app.py
+++ b/llama_cpp/server/app.py
@@ -490,6 +490,7 @@ async def create_chat_completion(
         "logit_bias_type",
         "user",
         "min_tokens",
+        "max_completion_tokens",
     }
     # TODO: use whitelisting and only include permitted fields.
     # TODO: only leave OpenAI API compatible fields.
@@ -513,6 +514,10 @@ async def create_chat_completion(
             kwargs["logits_processor"] = _min_tokens_logits_processor
         else:
             kwargs["logits_processor"].extend(_min_tokens_logits_processor)
+
+    # Override max_tokens with max_completion_tokens.
+    if body.max_completion_tokens is not None:
+        kwargs["max_tokens"] = body.max_completion_tokens
 
     try:
         iterator_or_completion: Union[

--- a/llama_cpp/server/app.py
+++ b/llama_cpp/server/app.py
@@ -290,7 +290,6 @@ async def create_completion(
         "best_of",
         "logit_bias_type",
         "user",
-        "min_tokens",
     }
     kwargs = body.model_dump(exclude=exclude)
 
@@ -303,15 +302,6 @@ async def create_completion(
 
     if body.grammar is not None:
         kwargs["grammar"] = llama_cpp.LlamaGrammar.from_string(body.grammar)
-
-    if body.min_tokens > 0:
-        _min_tokens_logits_processor = llama_cpp.LogitsProcessorList(
-            [llama_cpp.MinTokensLogitsProcessor(body.min_tokens, llama.token_eos())]
-        )
-        if "logits_processor" not in kwargs:
-            kwargs["logits_processor"] = _min_tokens_logits_processor
-        else:
-            kwargs["logits_processor"].extend(_min_tokens_logits_processor)
 
     try:
         iterator_or_completion: Union[
@@ -489,7 +479,6 @@ async def create_chat_completion(
         "n",
         "logit_bias_type",
         "user",
-        "min_tokens",
         "max_completion_tokens",
     }
     # TODO: use whitelisting and only include permitted fields.
@@ -505,15 +494,6 @@ async def create_chat_completion(
 
     if body.grammar is not None:
         kwargs["grammar"] = llama_cpp.LlamaGrammar.from_string(body.grammar)
-
-    if body.min_tokens > 0:
-        _min_tokens_logits_processor = llama_cpp.LogitsProcessorList(
-            [llama_cpp.MinTokensLogitsProcessor(body.min_tokens, llama.token_eos())]
-        )
-        if "logits_processor" not in kwargs:
-            kwargs["logits_processor"] = _min_tokens_logits_processor
-        else:
-            kwargs["logits_processor"].extend(_min_tokens_logits_processor)
 
     # Override max_tokens with max_completion_tokens.
     if body.max_completion_tokens is not None:

--- a/llama_cpp/server/model.py
+++ b/llama_cpp/server/model.py
@@ -24,21 +24,24 @@ class LlamaProxy:
         self._current_model: Optional[llama_cpp.Llama] = None
         self._current_model_alias: Optional[str] = None
 
+        # TODO: there should be no such thing as default model.
         self._default_model_settings: ModelSettings = models[0]
         self._default_model_alias: str = self._default_model_settings.model_alias  # type: ignore
 
+        # TODO: when _default_model is removed, what do we set as
+        #       current model and do we load it?
         # Load default model
         self._current_model = self.load_llama_from_model_settings(
             self._default_model_settings
         )
         self._current_model_alias = self._default_model_alias
 
-    def __call__(self, model: Optional[str] = None) -> llama_cpp.Llama:
+    def __call__(self, model: str = None) -> llama_cpp.Llama:
         if model is None:
             model = self._default_model_alias
 
         if model not in self._model_settings_dict:
-            model = self._default_model_alias
+            raise ValueError(f"Model {model} not found.")
 
         if model == self._current_model_alias:
             if self._current_model is not None:

--- a/llama_cpp/server/settings.py
+++ b/llama_cpp/server/settings.py
@@ -103,6 +103,7 @@ class ModelSettings(BaseSettings):
     offload_kqv: bool = Field(
         default=True, description="Whether to offload kqv to the GPU."
     )
+    # TODO: default this to True?
     flash_attn: bool = Field(
         default=False, description="Whether to use flash attention."
     )

--- a/llama_cpp/server/types.py
+++ b/llama_cpp/server/types.py
@@ -234,8 +234,9 @@ class CreateChatCompletionRequest(BaseModel):
         default=None,
     )
 
+    model: str = model_field
+
     # ignored or currently unsupported
-    model: Optional[str] = model_field
     n: Optional[int] = 1
     user: Optional[str] = Field(None)
 

--- a/llama_cpp/server/types.py
+++ b/llama_cpp/server/types.py
@@ -17,9 +17,11 @@ max_tokens_field = Field(
 )
 
 temperature_field = Field(
-    default=0.8,
+    default=1.0,
+    ge=0.0,
+    le=2.0,
     description="Adjust the randomness of the generated text.\n\n"
-    + "Temperature is a hyperparameter that controls the randomness of the generated text. It affects the probability distribution of the model's output tokens. A higher temperature (e.g., 1.5) makes the output more random and creative, while a lower temperature (e.g., 0.5) makes the output more focused, deterministic, and conservative. The default value is 0.8, which provides a balance between randomness and determinism. At the extreme, a temperature of 0 will always pick the most likely next token, leading to identical outputs in each run.",
+    + "Temperature is a hyperparameter that controls the randomness of the generated text. It affects the probability distribution of the model's output tokens. A higher temperature (e.g., 1.5) makes the output more random and creative, while a lower temperature (e.g., 0.5) makes the output more focused, deterministic, and conservative. The default value is 1, which provides a balance between randomness and determinism. At the extreme, a temperature of 0 will always pick the most likely next token, leading to identical outputs in each run. We recommend to alter this or top_p, but not both.",
 )
 
 top_p_field = Field(
@@ -27,7 +29,7 @@ top_p_field = Field(
     ge=0.0,
     le=1.0,
     description="Limit the next token selection to a subset of tokens with a cumulative probability above a threshold P.\n\n"
-    + "Top-p sampling, also known as nucleus sampling, is another text generation method that selects the next token from a subset of tokens that together have a cumulative probability of at least p. This method provides a balance between diversity and quality by considering both the probabilities of tokens and the number of tokens to sample from. A higher value for top_p (e.g., 0.95) will lead to more diverse text, while a lower value (e.g., 0.5) will generate more focused and conservative text.",
+    + "Top-p sampling, also known as nucleus sampling, is another text generation method that selects the next token from a subset of tokens that together have a cumulative probability of at least p. This method provides a balance between diversity and quality by considering both the probabilities of tokens and the number of tokens to sample from. A higher value for top_p (e.g., 0.95) will lead to more diverse text, while a lower value (e.g., 0.5) will generate more focused and conservative text. We recomment altering this or temperature, but not both.",
 )
 
 min_p_field = Field(

--- a/llama_cpp/server/types.py
+++ b/llama_cpp/server/types.py
@@ -212,6 +212,12 @@ class CreateChatCompletionRequest(BaseModel):
     max_tokens: Optional[int] = Field(
         default=None,
         description="The maximum number of tokens to generate. Defaults to inf",
+        deprecated="Deprecated in favor of max_completion_tokens",
+    )
+    max_completion_tokens: Optional[int] = Field(
+        gt=0,
+        default=None,
+        description="An upper bound for the number of tokens that can be generated for a completion. Defaults to inf",
     )
     min_tokens: int = min_tokens_field
     logprobs: Optional[bool] = Field(

--- a/llama_cpp/server/types.py
+++ b/llama_cpp/server/types.py
@@ -23,7 +23,7 @@ temperature_field = Field(
 )
 
 top_p_field = Field(
-    default=0.95,
+    default=1.0,
     ge=0.0,
     le=1.0,
     description="Limit the next token selection to a subset of tokens with a cumulative probability above a threshold P.\n\n"

--- a/llama_cpp/server/types.py
+++ b/llama_cpp/server/types.py
@@ -16,12 +16,6 @@ max_tokens_field = Field(
     default=16, ge=1, description="The maximum number of tokens to generate."
 )
 
-min_tokens_field = Field(
-    default=0,
-    ge=0,
-    description="The minimum number of tokens to generate. It may return fewer tokens if another condition is met (e.g. max_tokens, stop).",
-)
-
 temperature_field = Field(
     default=0.8,
     description="Adjust the randomness of the generated text.\n\n"
@@ -117,7 +111,6 @@ class CreateCompletionRequest(BaseModel):
     max_tokens: Optional[int] = Field(
         default=16, ge=0, description="The maximum number of tokens to generate."
     )
-    min_tokens: int = min_tokens_field
     temperature: float = temperature_field
     top_p: float = top_p_field
     min_p: float = min_p_field
@@ -219,7 +212,6 @@ class CreateChatCompletionRequest(BaseModel):
         default=None,
         description="An upper bound for the number of tokens that can be generated for a completion. Defaults to inf",
     )
-    min_tokens: int = min_tokens_field
     logprobs: Optional[bool] = Field(
         default=False,
         description="Whether to output the logprobs or not. Default is True",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "nekko_api"
 dynamic = ["version"]
 description = "OpenAI API compatible llama.cpp server"
 readme = "README.md"
-license = { text = "MIT" }
+license = { text = "Apache License 2.0" }
 authors = [
 ]
 dependencies = [
@@ -48,6 +48,7 @@ test = [
     "huggingface-hub>=0.23.0"
 ]
 dev = [
+    "mypy>=1.13.0",
     "black>=23.3.0",
     "twine>=4.0.2",
     "mkdocs>=1.4.3",


### PR DESCRIPTION
Implement several "low hanging fruit" to align `/v1/chat/completions` arguments with OpenAI API.

Most were already available, just needed verification, minor tweaking and testing.

Breaking change - `model` is now mandatory.

Closes #1, #2, #3.