### PR TITLE
chore/ci: Sets up deployments to demo

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-  # pull_request:
+  pull_request:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-  pull_request:
+  # pull_request:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/publish_image.yml
+++ b/.github/workflows/publish_image.yml
@@ -24,62 +24,65 @@ env:
   IMAGE_NAME: aifoundry-org/nekko-api
 
 jobs:
-  build-image:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-      attestations: write
-      id-token: write
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          submodules: recursive
-      - name: Log in to the container registry
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Extract metadata for Docker
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          tags: |
-            type=raw,value=${{ inputs.tag || 'test' }}
-            type=sha
-      - name: Build and push image
-        id: push
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: docker/simple/Dockerfile
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+  # build-image:
+  #   runs-on: ubuntu-latest
+  #   permissions:
+  #     contents: read
+  #     packages: write
+  #     attestations: write
+  #     id-token: write
+  #   steps:
+  #     - name: Checkout code
+  #       uses: actions/checkout@v4
+  #       with:
+  #         submodules: recursive
+  #     - name: Log in to the container registry
+  #       uses: docker/login-action@v3
+  #       with:
+  #         registry: ${{ env.REGISTRY }}
+  #         username: ${{ github.actor }}
+  #         password: ${{ secrets.GITHUB_TOKEN }}
+  #     - name: Extract metadata for Docker
+  #       id: meta
+  #       uses: docker/metadata-action@v5
+  #       with:
+  #         images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+  #         tags: |
+  #           type=raw,value=${{ inputs.tag || 'test' }}
+  #           type=sha
+  #     - name: Build and push image
+  #       id: push
+  #       uses: docker/build-push-action@v6
+  #       with:
+  #         context: .
+  #         file: docker/simple/Dockerfile
+  #         push: true
+  #         tags: ${{ steps.meta.outputs.tags }}
+  #         labels: ${{ steps.meta.outputs.labels }}
 
   deploy-to-demo:
     runs-on: ubuntu-latest
     env:
       DEMO_USER: ${{ secrets.DEMO_USER }}
       DEMO_HOST: ${{ secrets.DEMO_HOST }}
+      DEMO_SSH_KEY: ${{ secrets.DEMO_SSH_KEY }}
       DEMO_APP_DIR: ${{ secrets.DEMO_APP_DIR }}
     if: ${{ inputs.deploy_to_demo || true }}
-    needs: [build-image]
+    # needs: [build-image]
     permissions:
       contents: read
       packages: read
       attestations: read
     steps:
       - name: Deploy to demo
-        if: ${{ env.DEMO_USER != '' && env.DEMO_HOST != '' && env.DEMO_APP_DIR != '' }}
+        if: ${{ env.DEMO_USER != '' && env.DEMO_HOST != '' && env.DEMO_SSH_KEY != '' && env.DEMO_APP_DIR != '' }}
         run: >
+          ssh-add - <<< "${{ env.DEMO_SSH_KEY }}"
+
           ssh ${{ env.DEMO_USER }}@${{ env.DEMO_HOST }}
           'cd ${{ env.DEMO_APP_DIR }} &&
           echo "NEKKO_IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ inputs.tag || 'test' }}" > .env &&
           sudo docker-compose pull &&
           sudo docker-compose up --force-recreate -d'
-      - if: ${{ env.DEMO_USER == '' || env.DEMO_HOST == '' || env.DEMO_APP_DIR == '' }}
+      - if: ${{ env.DEMO_USER == '' || env.DEMO_HOST == '' || env.DEMO_SSH_KEY == '' || env.DEMO_APP_DIR == '' }}
         run: echo 'Could not find demo deployment settings in secrets, skipping'

--- a/.github/workflows/publish_image.yml
+++ b/.github/workflows/publish_image.yml
@@ -24,41 +24,41 @@ env:
   IMAGE_NAME: aifoundry-org/nekko-api
 
 jobs:
-  # build-image:
-  #   runs-on: ubuntu-latest
-  #   permissions:
-  #     contents: read
-  #     packages: write
-  #     attestations: write
-  #     id-token: write
-  #   steps:
-  #     - name: Checkout code
-  #       uses: actions/checkout@v4
-  #       with:
-  #         submodules: recursive
-  #     - name: Log in to the container registry
-  #       uses: docker/login-action@v3
-  #       with:
-  #         registry: ${{ env.REGISTRY }}
-  #         username: ${{ github.actor }}
-  #         password: ${{ secrets.GITHUB_TOKEN }}
-  #     - name: Extract metadata for Docker
-  #       id: meta
-  #       uses: docker/metadata-action@v5
-  #       with:
-  #         images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-  #         tags: |
-  #           type=raw,value=${{ inputs.tag || 'test' }}
-  #           type=sha
-  #     - name: Build and push image
-  #       id: push
-  #       uses: docker/build-push-action@v6
-  #       with:
-  #         context: .
-  #         file: docker/simple/Dockerfile
-  #         push: true
-  #         tags: ${{ steps.meta.outputs.tags }}
-  #         labels: ${{ steps.meta.outputs.labels }}
+  build-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Log in to the container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=${{ inputs.tag }}
+            type=sha
+      - name: Build and push image
+        id: push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/simple/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
 
   deploy-to-demo:
     runs-on: ubuntu-latest
@@ -67,8 +67,8 @@ jobs:
       DEMO_HOST: ${{ secrets.DEMO_HOST }}
       DEMO_SSH_KEY: ${{ secrets.DEMO_SSH_KEY }}
       DEMO_APP_DIR: ${{ secrets.DEMO_APP_DIR }}
-    if: ${{ inputs.deploy_to_demo || true }}
-    # needs: [build-image]
+    if: ${{ inputs.deploy_to_demo }}
+    needs: [build-image]
     permissions:
       contents: read
       packages: read
@@ -90,7 +90,7 @@ jobs:
         if: ${{ env.DEMO_USER != '' && env.DEMO_HOST != '' && env.DEMO_SSH_KEY != '' && env.DEMO_APP_DIR != '' }}
         run: >
           ssh demo 'cd ${{ env.DEMO_APP_DIR }} &&
-          echo "NEKKO_IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ inputs.tag || 'test' }}" > .env &&
+          echo "NEKKO_IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ inputs.tag }}" > .env &&
           sudo docker-compose pull &&
           sudo docker-compose up --force-recreate -d'
       - if: ${{ env.DEMO_USER == '' || env.DEMO_HOST == '' || env.DEMO_SSH_KEY == '' || env.DEMO_APP_DIR == '' }}

--- a/.github/workflows/publish_image.yml
+++ b/.github/workflows/publish_image.yml
@@ -64,18 +64,21 @@ jobs:
 
   deploy-to-demo:
     runs-on: ubuntu-latest
-    if: ${{ inputs.tag && secrets.DEMO_USER && secrets.DEMO_HOST && secrets.DEMO_APP_DIR }}
+    env:
+      DEMO_USER: ${{ secrets.DEMO_USER }}
+      DEMO_HOST: ${{ secrets.DEMO_HOST }}
+      DEMO_APP_DIR: ${{ secrets.DEMO_APP_DIR }}
+    if: ${{ inputs.tag && env.DEMO_USER != '' && env.DEMO_HOST != '' && env.DEMO_APP_DIR != '' }}
     needs: [build-image]
     permissions:
       contents: read
       packages: read
       attestations: read
-      id-token: read
     steps:
       - name: Deploy to demo
         run: >
-          ssh ${{ secrets.DEMO_USER }}@${{ secrets.DEMO_HOST }}
-          'cd ${{ secrets.DEMO_APP_DIR }} &&
+          ssh ${{ env.DEMO_USER }}@${{ env.DEMO_HOST }}
+          'cd ${{ env.DEMO_APP_DIR }} &&
           echo "NEKKO_IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}" > .env &&
           sudo docker-compose pull &&
           sudo docker-compose up --force-recreate -d'

--- a/.github/workflows/publish_image.yml
+++ b/.github/workflows/publish_image.yml
@@ -1,9 +1,6 @@
 name: publish_image
 
 on:
-  push:
-    branches:
-      - chore/demo-deploy
   workflow_dispatch:
     inputs:
       tag:

--- a/.github/workflows/publish_image.yml
+++ b/.github/workflows/publish_image.yml
@@ -74,13 +74,22 @@ jobs:
       packages: read
       attestations: read
     steps:
+      - name: Configure ssh
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ env.DEMO_SSH_KEY }}" > ~/.ssh/id_rsa
+          chmod 600 ~/.ssh/id_rsa
+          cat >> ~/.ssh/config <<END
+          Host demo
+            HostName $DEMO_HOST
+            User $DEMO_USER
+            IdentityFile ~/.ssh/id_rsa
+            StrictHostKeyChecking no
+          END
       - name: Deploy to demo
         if: ${{ env.DEMO_USER != '' && env.DEMO_HOST != '' && env.DEMO_SSH_KEY != '' && env.DEMO_APP_DIR != '' }}
         run: >
-          ssh-add - <<< "${{ env.DEMO_SSH_KEY }}"
-
-          ssh ${{ env.DEMO_USER }}@${{ env.DEMO_HOST }}
-          'cd ${{ env.DEMO_APP_DIR }} &&
+          ssh demo 'cd ${{ env.DEMO_APP_DIR }} &&
           echo "NEKKO_IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ inputs.tag || 'test' }}" > .env &&
           sudo docker-compose pull &&
           sudo docker-compose up --force-recreate -d'

--- a/.github/workflows/publish_image.yml
+++ b/.github/workflows/publish_image.yml
@@ -59,17 +59,13 @@ jobs:
 
   deploy-to-demo:
     runs-on: ubuntu-latest
+    if: ${{ inputs.deploy_to_demo }}
     env:
       DEMO_USER: ${{ secrets.DEMO_USER }}
       DEMO_HOST: ${{ secrets.DEMO_HOST }}
       DEMO_SSH_KEY: ${{ secrets.DEMO_SSH_KEY }}
       DEMO_APP_DIR: ${{ secrets.DEMO_APP_DIR }}
-    if: ${{ inputs.deploy_to_demo }}
     needs: [build-image]
-    permissions:
-      contents: read
-      packages: read
-      attestations: read
     steps:
       - name: Configure ssh
         run: |

--- a/.github/workflows/publish_image.yml
+++ b/.github/workflows/publish_image.yml
@@ -68,7 +68,7 @@ jobs:
       DEMO_USER: ${{ secrets.DEMO_USER }}
       DEMO_HOST: ${{ secrets.DEMO_HOST }}
       DEMO_APP_DIR: ${{ secrets.DEMO_APP_DIR }}
-    if: ${{ inputs.tag && env.DEMO_USER != '' && env.DEMO_HOST != '' && env.DEMO_APP_DIR != '' }}
+    if: ${{ inputs.tag }}
     needs: [build-image]
     permissions:
       contents: read
@@ -76,9 +76,12 @@ jobs:
       attestations: read
     steps:
       - name: Deploy to demo
+        if: ${{ env.DEMO_USER != '' && env.DEMO_HOST != '' && env.DEMO_APP_DIR != '' }}
         run: >
           ssh ${{ env.DEMO_USER }}@${{ env.DEMO_HOST }}
           'cd ${{ env.DEMO_APP_DIR }} &&
           echo "NEKKO_IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}" > .env &&
           sudo docker-compose pull &&
           sudo docker-compose up --force-recreate -d'
+      - if: ${{ env.DEMO_USER == '' || env.DEMO_HOST == '' || env.DEMO_APP_DIR == '' }}
+        run: echo 'Could not find demo deployment settings in secrets, skipping'

--- a/.github/workflows/publish_image.yml
+++ b/.github/workflows/publish_image.yml
@@ -49,8 +49,6 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=raw,value=${{ inputs.tag }}
-            type=ref,event=branch
-            type=ref,event=workflow_dispatch
             type=sha
       - name: Build and push image
         id: push

--- a/.github/workflows/publish_image.yml
+++ b/.github/workflows/publish_image.yml
@@ -40,7 +40,11 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          tags: ${{ inputs.tag }}
+          tags: |
+            type=raw,value=${{ inputs.tag }}
+            type=ref,event=branch
+            type=ref,event=workflow_dispatch
+            type=sha
       - name: Build and push image
         id: push
         uses: docker/build-push-action@v6

--- a/.github/workflows/publish_image.yml
+++ b/.github/workflows/publish_image.yml
@@ -8,6 +8,10 @@ on:
         description: Image tag
         required: true
         default: latest
+      deploy_to_demo:
+        type: boolean
+        description: Deploy new image to demo?
+        default: true
 
 concurrency:
   group: ${{ github.workflow }}
@@ -54,3 +58,21 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+  deploy-to-demo:
+    runs-on: ubuntu-latest
+    if: ${{ inputs.tag && secrets.DEMO_USER && secrets.DEMO_HOST && secrets.DEMO_APP_DIR }}
+    needs: [build-image]
+    permissions:
+      contents: read
+      packages: read
+      attestations: read
+      id-token: read
+    steps:
+      - name: Deploy to demo
+        run: >
+          ssh ${{ secrets.DEMO_USER }}@${{ secrets.DEMO_HOST }}
+          'cd ${{ secrets.DEMO_APP_DIR }} &&
+          echo "NEKKO_IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}" > .env &&
+          sudo docker-compose pull &&
+          sudo docker-compose up --force-recreate -d'

--- a/.github/workflows/publish_image.yml
+++ b/.github/workflows/publish_image.yml
@@ -1,6 +1,9 @@
 name: publish_image
 
 on:
+  push:
+    branches:
+      - chore/demo-deploy
   workflow_dispatch:
     inputs:
       tag:

--- a/.github/workflows/publish_image.yml
+++ b/.github/workflows/publish_image.yml
@@ -48,7 +48,7 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=raw,value=${{ inputs.tag }}
+            type=raw,value=${{ inputs.tag || 'test' }}
             type=sha
       - name: Build and push image
         id: push
@@ -66,7 +66,7 @@ jobs:
       DEMO_USER: ${{ secrets.DEMO_USER }}
       DEMO_HOST: ${{ secrets.DEMO_HOST }}
       DEMO_APP_DIR: ${{ secrets.DEMO_APP_DIR }}
-    if: ${{ inputs.tag }}
+    if: ${{ inputs.deploy_to_demo || true }}
     needs: [build-image]
     permissions:
       contents: read
@@ -78,7 +78,7 @@ jobs:
         run: >
           ssh ${{ env.DEMO_USER }}@${{ env.DEMO_HOST }}
           'cd ${{ env.DEMO_APP_DIR }} &&
-          echo "NEKKO_IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}" > .env &&
+          echo "NEKKO_IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ inputs.tag || 'test' }}" > .env &&
           sudo docker-compose pull &&
           sudo docker-compose up --force-recreate -d'
       - if: ${{ env.DEMO_USER == '' || env.DEMO_HOST == '' || env.DEMO_APP_DIR == '' }}


### PR DESCRIPTION
Closes #17.

The "Build image" workflow will now have a checkbox for deploying the new image to the demo server.

Example of a successful deployment: https://github.com/aifoundry-org/NekkoAPI/actions/runs/12350697479/job/34464098416