### PR TITLE
Chat: Add StructuredOutput-like mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,9 @@ docker:
 run-server:
 	python3 -m llama_cpp.server --model ${MODEL}
 
+run:
+	python3 -m llama_cpp.server --config_file=./examples/settings.json
+
 run-example-docker: example-models
 	docker run \
 	  -v ./models:/app/models \

--- a/examples/openai-client.py
+++ b/examples/openai-client.py
@@ -9,35 +9,111 @@ uri = "http://localhost:8000/v1/"
 # uri = "https://api.openai.com/v1/"
 
 client = OpenAI(
-	base_url=uri
+    base_url=uri
 )
 
-messages = [
-	{
-		"role": "system",
-		"content": "You are a helpful AI assitant named Nekko. " \
-		           "For some reason you like cats. " \
-		           "You always answer in numbered lists, top 3 items only."
-	},
-	{
-		"role": "user",
-		"content": "What should I see in Japan? Thanks!"
-	}
-]
 
-stream = client.chat.completions.create(
-    model=model, 
-	messages=messages, 
-	max_completion_tokens=200,
-	stop=["4.", "sushi"],
-	top_p=0.3,
-	# temperature=2.0,
-	stream=True
-)
+def example_simple():
+    messages = [
+        {
+            "role": "system",
+            "content": "You are a helpful AI assitant named Nekko. "
+                       "For some reason you like cats. "
+                       "Answer in numbered list."
+        },
+        {
+            "role": "user",
+            "content": "What should I see in Japan? Thanks!"
+        }
+    ]
 
-for chunk in stream:
-    if chunk.choices[0].delta.content is None:
-    	continue
-    print(chunk.choices[0].delta.content, end="")
+    stream = client.chat.completions.create(
+        model=model,
+        messages=messages,
+        max_completion_tokens=200,
+        stop=["4.", "sushi"],
+        top_p=0.3,
+        # temperature=2.0,
+        stream=True
+    )
 
-print('\n')
+    for chunk in stream:
+        if chunk.choices[0].delta.content is None:
+            continue
+        print(chunk.choices[0].delta.content, end="")
+
+    print('\n')
+
+
+def example_structured_output():
+    weather = """
+    Steady light rain this evening.
+    Showers continuing overnight.
+    Low 44F. Winds SSW at 10 to 20 mph.
+    Chance of rain 80%.
+    """
+    schema = {
+      "name": "weather_forecast",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "string",
+            "maxLength": 20
+          },
+          "temperature": {
+            "type": "number",
+          },
+          "wind_speed": {
+            "type": "number"
+          },
+          "wind_direction": {
+            "type": "string"
+          },
+          "rain": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "description",
+          "temperature",
+          "wind_speed",
+          "wind_direction",
+          "rain"
+        ],
+        "additionalProperties": False
+      },
+      "strict": True
+    }
+    messages = [
+        {
+            "role": "system",
+            "content": "You are a helpful AI assitant named Nekko."
+        },
+        {
+            "role": "user",
+            "content": "Please output weather forecast as JSON. " +
+                       f"The input is bellow: {weather}"
+        }
+    ]
+
+    completion = client.chat.completions.create(
+        model=model,
+        messages=messages,
+        response_format={
+            "type": "json_schema",
+            "json_schema": schema
+        }
+    )
+
+    message = completion.choices[0].message
+    if message.content is not None:
+        print(message.content)
+
+
+def main():
+    example_structured_output()
+
+
+if __name__ == "__main__":
+    main()

--- a/llama_cpp/server/app.py
+++ b/llama_cpp/server/app.py
@@ -492,6 +492,15 @@ async def create_chat_completion(
             else body.logit_bias
         )
 
+    # LLama.cpp doesn't make distinction between "json_object" and "json_schema"
+    # types.
+    # Rename "json_schema" into "schema" to avoid touching llama.cpp
+    if body.response_format is not None:
+      if body.response_format["json_schema"] is not None:
+         kwargs["response_format"]["type"] = "json_object"
+         kwargs["response_format"]["schema"] = body.response_format["json_schema"].get("schema")
+         del kwargs["response_format"]["json_schema"]
+
     if body.grammar is not None:
         kwargs["grammar"] = llama_cpp.LlamaGrammar.from_string(body.grammar)
 


### PR DESCRIPTION
This adds Structured Output-like mode to chat completions.

There are some differences (described in https://github.com/aifoundry-org/NekkoAPI/issues/23#issuecomment-2554026156) from the OpenAI API.

Respecting `strict` would be prohibitively difficult (and useless) while "automatic" intent communication of schema and instruction to return JSON requires modifying chat formats for each model individually. We'll have to make decisions what we do in such cases (there will be more features like that).

By the way, unlike OpenAI, we **do** support `additionalProperties: true` :)

Typing of the JSONSchema could be improved (added) which would help with error messages. Not trivial, but doable.

Closes #23 