### PR TITLE
chore/deploy-instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ LLM models from [Hugging Face](https://huggingface.co/) with:
 make example-models
 ```
 
+### Running the API
+
 With models downloaded you can run the Nekko API server to use them
 with:
 
@@ -49,6 +51,34 @@ API will be accesible on `http://localhost:8000`.
 
 There is a small example using OpenAPI client library that can
 be used to try out the server in `examples/openai-client.py`.
+
+### Running the API with Open WebUI
+
+If you would like to explore the models with an intuitive GUI, run the provided
+example script:
+
+```sh
+make run-demo
+```
+
+Both the API and the UI will be available on `http://localhost`.
+
+> [!WARNING]
+> Not every feature of Open WebUI will work at this time. The API server is
+> currently unstable and feature-incomplete and may crash if called with
+> unsupported parameters.
+
+## Deployment
+
+### With Docker Compose
+
+> [!WARNING]
+> At the moment, our images are only built for x86_64 machines. If you need to
+> deploy the project to a different architecture, take a look at
+> `docker/web/docker-compose.yml` where the image is built from scratch.
+
+* [API-only setup](/examples/docker-compose/api)
+* [API + UI + nginx](/examples/docker-compose/ui)
 
 
 ## Development

--- a/examples/docker-compose/api/docker-compose.yml
+++ b/examples/docker-compose/api/docker-compose.yml
@@ -1,0 +1,25 @@
+services:
+  nekko_api:
+    image: ghcr.io/aifoundry-org/nekko-api:latest
+    cap_add:
+      - SYS_RESOURCE
+    volumes:
+      - ../../../models:/app/models:ro
+      - ./settings.json:/app/settings.json:ro
+    environment:
+      - CONFIG_FILE=settings.json
+    ports:
+      - 80:8000
+    healthcheck:
+      test:
+        - CMD
+        - curl
+        - -f
+        - -H
+        - "Authorization: Bearer YOUR_API_KEY"
+        - http://0.0.0.0:8000/v1/models
+      interval: 30s
+      timeout: 5s
+      start_period: 30s
+      start_interval: 5s
+      retries: 5

--- a/examples/docker-compose/api/settings.json
+++ b/examples/docker-compose/api/settings.json
@@ -1,0 +1,22 @@
+{
+  "host": "0.0.0.0",
+  "port": 8000,
+  "api_key": "YOUR_API_KEY",
+  "models": [
+      {
+        "model": "models/Llama-3.2-1B-Instruct-Q5_K_S.gguf",
+        "model_alias": "llama",
+        "n_ctx": 8192
+      },
+      {
+        "model": "models/SmolLM2-135M-Instruct-Q6_K.gguf",
+        "model_alias": "smolm2-135m",
+        "n_ctx": 8192
+      },
+      {
+        "model": "models/OLMo-7B-Instruct-hf-0724-Q4_K.gguf",
+        "model_alias": "olmo-7b",
+        "n_ctx": 2048
+      }
+  ]
+}

--- a/examples/docker-compose/ui/docker-compose.yml
+++ b/examples/docker-compose/ui/docker-compose.yml
@@ -1,0 +1,73 @@
+services:
+  nekko_api:
+    image: ghcr.io/aifoundry-org/nekko-api:latest
+    cap_add:
+      - SYS_RESOURCE
+    volumes:
+      - ../../../models:/app/models:ro
+      - ./settings.json:/app/settings.json:ro
+    environment:
+      - CONFIG_FILE=settings.json
+    networks:
+      - nekko_api-network
+    expose:
+      - 8000
+    healthcheck:
+      test:
+        - CMD
+        - curl
+        - -f
+        - -H
+        - "Authorization: Bearer YOUR_API_KEY"
+        - http://0.0.0.0:8000/v1/models
+      interval: 30s
+      timeout: 5s
+      start_period: 30s
+      start_interval: 5s
+      retries: 5
+
+  ui:
+    image: ghcr.io/open-webui/open-webui:0.4.8
+    volumes:
+      - ui:/app/backend/data
+    environment:
+      - WEBUI_AUTH=false
+      - WEBUI_NAME=NekkoAPI UI
+      - ENABLE_OLLAMA_API=false
+      - OPENAI_API_BASE_URL=http://nekko_api:8000/v1
+    networks:
+      - nekko_api-network
+    expose:
+      - 8080
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://0.0.0.0:8080/health"]
+      interval: 30s
+      timeout: 5s
+      start_period: 2m
+      start_interval: 5s
+      retries: 5
+    depends_on:
+      nekko_api:
+        condition: service_healthy
+
+  nginx:
+    platform: linux/amd64
+    image: nginx:alpine
+    volumes:
+      - ./nginx.conf:/etc/nginx/nginx.conf:ro
+    networks:
+      - nekko_api-network
+    ports:
+      - 80:80
+    depends_on:
+      nekko_api:
+        condition: service_healthy
+      ui:
+        condition: service_healthy
+
+networks:
+  nekko_api-network:
+    driver: bridge
+
+volumes:
+  ui:

--- a/examples/docker-compose/ui/nginx.conf
+++ b/examples/docker-compose/ui/nginx.conf
@@ -1,0 +1,30 @@
+events {}
+
+http {
+        server {
+                listen 80;
+                client_max_body_size 2M;
+
+                location / {
+                        proxy_pass http://ui:8080;
+
+                        proxy_set_header Host $host;
+                        proxy_set_header X-Real-IP $remote_addr;
+                        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+
+                        proxy_http_version 1.1;
+                        proxy_set_header Upgrade $http_upgrade;
+                        proxy_set_header Connection "upgrade";
+                }
+
+                location /v1 {
+                        proxy_pass http://nekko_api:8000;
+
+                        proxy_set_header Host $host;
+                        proxy_set_header X-Real-IP $remote_addr;
+                        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+
+                        proxy_read_timeout 20m;
+                }
+        }
+}

--- a/examples/docker-compose/ui/settings.json
+++ b/examples/docker-compose/ui/settings.json
@@ -1,0 +1,22 @@
+{
+  "host": "0.0.0.0",
+  "port": 8000,
+  "api_key": "YOUR_API_KEY",
+  "models": [
+      {
+        "model": "models/Llama-3.2-1B-Instruct-Q5_K_S.gguf",
+        "model_alias": "llama",
+        "n_ctx": 8192
+      },
+      {
+        "model": "models/SmolLM2-135M-Instruct-Q6_K.gguf",
+        "model_alias": "smolm2-135m",
+        "n_ctx": 8192
+      },
+      {
+        "model": "models/OLMo-7B-Instruct-hf-0724-Q4_K.gguf",
+        "model_alias": "olmo-7b",
+        "n_ctx": 2048
+      }
+  ]
+}


### PR DESCRIPTION
Closes #27.

Currently blocked by our Docker images being private.