### PR TITLE
Making sure there's a folder for models download

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,14 +66,17 @@ run-demo: example-models
 
 example-models: models/SmolLM2-135M-Instruct-Q6_K.gguf models/Llama-3.2-1B-Instruct-Q5_K_S.gguf models/OLMo-7B-Instruct-hf-0724-Q4_K.gguf
 
-models/SmolLM2-135M-Instruct-Q6_K.gguf:
+models/SmolLM2-135M-Instruct-Q6_K.gguf: | models
 	curl -L https://huggingface.co/lmstudio-community/SmolLM2-135M-Instruct-GGUF/resolve/main/SmolLM2-135M-Instruct-Q6_K.gguf -o $@
 
-models/Llama-3.2-1B-Instruct-Q5_K_S.gguf:
+models/Llama-3.2-1B-Instruct-Q5_K_S.gguf: | models
 	curl -L https://huggingface.co/bartowski/Llama-3.2-1B-Instruct-GGUF/resolve/main/Llama-3.2-1B-Instruct-Q5_K_S.gguf -o $@
 
-models/OLMo-7B-Instruct-hf-0724-Q4_K.gguf:
+models/OLMo-7B-Instruct-hf-0724-Q4_K.gguf: | models
 	curl -L https://huggingface.co/aifoundry-org/OLMo-7B-0724-Instruct-hf-Quantized/resolve/main/OLMo-7B-Instruct-hf-0724-Q4_K.gguf -o $@
+
+models:
+	mkdir models
 
 clean:
 	- cd vendor/llama.cpp && make clean
@@ -84,6 +87,7 @@ clean:
 	- rm llama_cpp/lib/*.metal
 	- rm llama_cpp/lib/*.dll
 	- rm llama_cpp/lib/*.lib
+	- rm -rf models
 
 .PHONY: \
 	update \


### PR DESCRIPTION
Right now, running `make example-models` fails since by default there's no folder for models to be placed into. This fixes that.