### PR TITLE
Log user, metadata and promp/completion

### DIFF
--- a/docker/web/docker-compose.yml
+++ b/docker/web/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       - ../../examples/settings.json:/app/settings.json
     environment:
       - CONFIG_FILE=settings.json
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://otel_collector:4317
     networks:
       - nekko_api-network
     expose:
@@ -63,6 +64,18 @@ services:
         condition: service_healthy
       ui:
         condition: service_healthy
+
+  otel_collector:
+    platform: linux/amd64
+    image: otel/opentelemetry-collector:latest
+    networks:
+      - nekko_api-network
+    ports:
+      - 4317 # OTLP gRPC
+    command: ["--config=/etc/otel-collector-config.yaml"]
+    volumes:
+      - ./otel-collector-config.yaml:/etc/otel-collector-config.yaml
+    
 
 networks:
   nekko_api-network:

--- a/docker/web/otel-collector-config.yaml
+++ b/docker/web/otel-collector-config.yaml
@@ -1,0 +1,20 @@
+receivers:
+  otlp: # the OTLP receiver the app is sending logs to
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+
+processors:
+  batch:
+
+exporters:
+  debug:
+    verbosity: detailed
+
+service:
+  pipelines:
+    logs/dev:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [debug]
+

--- a/examples/openai-client.py
+++ b/examples/openai-client.py
@@ -38,6 +38,9 @@ def example_simple():
         # Multiple forms of the word time: " time", "time", "Time" etc
         # Assumes GPT-4 tokenizer (works with llama models)
         # logit_bias={ 1712: -100, 3115: -100, 15487: -100, 892: -100, 1489: -100 },
+        user="username",
+        store=True,
+        metadata={"chat_title": "Asian vacation"},
         stream=True
     )
 

--- a/llama_cpp/server/transaction_logs.py
+++ b/llama_cpp/server/transaction_logs.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import os
+import platform
+from time import time_ns
+
+from typing import Annotated, Literal, Union
+from typing_extensions import TypedDict, NotRequired
+
+from opentelemetry.sdk._logs import LoggerProvider, LogRecord
+from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
+from opentelemetry.sdk.resources import Resource
+from opentelemetry._logs import NoOpLogger
+from opentelemetry._logs.severity import SeverityNumber
+from opentelemetry.exporter.otlp.proto.grpc._log_exporter import OTLPLogExporter
+
+
+def setup_logger():
+    instance = platform.node()
+    resource = Resource(attributes={
+        "service.name": "nekko_api",
+        "service.instance.id": instance,
+    })
+
+    logger = NoOpLogger('nekko-api')
+
+    if os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT"):
+        logger_provider = LoggerProvider(resource=resource)
+
+        otlp_exporter = OTLPLogExporter()
+
+        logger_provider.add_log_record_processor(BatchLogRecordProcessor(otlp_exporter))
+
+        logger = logger_provider.get_logger("nekko-api")
+
+    def log(event):
+        timestamp = time_ns()
+        attributes = event
+        record = LogRecord(
+                timestamp=timestamp,
+                observed_timestamp=timestamp,
+                resource=resource,
+                attributes=attributes,
+                span_id=0,
+                trace_id=0,
+                trace_flags=0,
+                severity_number=SeverityNumber(0),
+            )
+        logger.emit(record)
+
+    return log
+
+
+class ChatCompletionEvent(TypedDict):
+    transaction_id: Annotated[str]
+    transacton_type: Literal["chat_completion"]
+    user: Annotated[NotRequired[str]]
+    metadata: Annotated[NotRequired[str]]
+    store: Annotated[NotRequired[Union[bool,str]]]
+    completion: Annotated[NotRequired[str]]
+

--- a/llama_cpp/server/types.py
+++ b/llama_cpp/server/types.py
@@ -280,7 +280,21 @@ class CreateChatCompletionRequest(BaseModel):
 
     # ignored or currently unsupported
     n: Optional[int] = 1
-    user: Optional[str] = Field(None)
+
+    user: Optional[str] = Field(
+        default=None,
+        description="A unique identifier for the end-user making the request."
+    )
+
+    metadata: Optional[JsonType] = Field(
+        default=None,
+        description="metadata attached to request."
+    )
+
+    store: Optional[Union[bool, str]] = Field(
+        default=None,
+        description="Store the result of chat completion for later use if true. If value is string, attach that string as a label to the stored completion."
+    )
 
     # llama.cpp specific parameters
     top_k: int = top_k_field

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,9 @@ server = [
     "sse-starlette>=1.6.1",
     "starlette-context>=0.3.6,<0.4",
     "PyYAML>=5.1",
+    "opentelemetry-api>=1.29.0",
+    "opentelemetry-sdk>=1.29.0",
+    "opentelemetry-exporter-otlp>=1.29.0",
 ]
 test = [
     "openai>=1.57.2",


### PR DESCRIPTION
Implement transaction logs by using
OpenTelemetry logs.

Publish logs to OTLP collector
when environment variable
`OTEL_OTLP_EXPORTER_ENDPOINT` is set.

Log user.

Log metadata (serialized to JSON).

If store is True or string, log
`messages` (serialized to JSON)
and completion response (serialized to JSON).
Completion response is logged with a separate log
record *after* the completion is generated.

Both log records have the same `transaction_id`
field (random v4 UUID.)

Provided example docker-compose file is configured to run
opentelemetry collector container. Collector just prints
logs to the output (debug exporter).

`make run-demo` is the way to run example docker compose with collection enabled. Then
you can use any OpenAI client to connect to the NekkoAPI (served on `http://localhost:80/v1/`)
or use bundled UI (`http://localhost:80`).

Closes #49, #50, #66, #68, #69